### PR TITLE
Collections and elements API enhancements

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -2,7 +2,17 @@ class Api::V1::CollectionsController < ApiController
 
   def index
     respond_to do |f|
-      f.json { render(:json => current_property.collections) }
+      f.json do
+        @collections = if params[:type] && current_collection_type
+          current_property.collections.by_title
+                          .with_type(current_collection_type.name)
+        elsif params[:type]
+          []
+        else
+          current_property.collections.by_title
+        end
+        render(:json => @collections)
+      end
     end
   end
 

--- a/app/controllers/api/v1/elements_controller.rb
+++ b/app/controllers/api/v1/elements_controller.rb
@@ -27,6 +27,15 @@ class Api::V1::ElementsController < ApiController
     end
   end
 
+  def create
+    @template = current_property.find_template(params[:template])
+    forbidden if @template.nil?
+    @element = Element.new(:template_data => element_params.to_hash)
+    @element.property = current_property
+    @element.template_name = @template.name
+    render(:json => (@element.save ? @element : @element.errors.messages))
+  end
+
   def webhook
     Rails.logger.debug "****************************************"
     Rails.logger.debug "\n----- INCOMING WEBHOOK -----\n"
@@ -34,5 +43,11 @@ class Api::V1::ElementsController < ApiController
     Rails.logger.debug "****************************************"
     render :nothing => true
   end
+
+  private
+
+    def element_params
+      params.permit(@template.fields.collect(&:name))
+    end
 
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -6,7 +6,8 @@ class ApiController < ActionController::Base
   caches_action :index, :cache_path => :index_cache_path.to_proc
   caches_action :show, :cache_path => :show_cache_path.to_proc
 
-  helper_method :current_property
+  helper_method :current_collection_type,
+                :current_property
 
   def options
     render :nothing => true
@@ -51,6 +52,14 @@ class ApiController < ActionController::Base
       headers['Access-Control-Allow-Methods'] = 'POST, PUT, DELETE, GET, OPTIONS'
       headers['Access-Control-Request-Method'] = '*'
       headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+    end
+
+    # ------------------------------------------ Collections
+
+    def current_collection_type
+      @current_collection_type ||= begin
+        current_property.find_collection_type(params[:type])
+      end
     end
 
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,12 +1,16 @@
 class ApiController < ActionController::Base
 
   before_filter :allow_cors
-  before_filter :authenticate_api_user!
+  before_filter :authenticate_api_user!, :except => [:options]
 
   caches_action :index, :cache_path => :index_cache_path.to_proc
   caches_action :show, :cache_path => :show_cache_path.to_proc
 
   helper_method :current_property
+
+  def options
+    render :nothing => true
+  end
 
   protected
 

--- a/app/helpers/field_helper.rb
+++ b/app/helpers/field_helper.rb
@@ -4,6 +4,10 @@ module FieldHelper
     form_obj.input field.name.to_sym, :required => field.required?
   end
 
+  def field_text_html(form_obj, field)
+    form_obj.input field.name.to_sym, :as => :text, :required => field.required?
+  end
+
   def field_document_html(form_obj, field)
     path = new_property_document_path(current_property)
     document = Document.find_by_id(form_obj.object.send(field.name))

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -75,12 +75,15 @@ class Collection < ActiveRecord::Base
     if item_data.present?
       JSON.parse(item_data).each do |k1, v1|
         e1 = els.select { |e| e.id == k1['id'] }.first
+        next if e1.blank?
         c1 = []
         k1['children'].each do |k2, v2|
           e2 = els.select { |e| e.id == k2['id'] }.first
+          next if e2.blank?
           c2 = []
           k2['children'].each do |k3, v3|
             e3 = els.select { |e| e.id == k3['id'] }.first
+            next if e3.blank?
             c2 << e3.as_json({})
           end
           c1 << e2.as_json({}).merge(:children => c2)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :properties, :only => [:show] do
-        resources :elements, :only => [:index, :show, :create]
+        resources :elements, :only => [:index, :show, :create] do
+          post 'webhook', :on => :collection if Rails.env.development?
+        end
+        resources :collections, :only => [:index, :show]
       end
       resources :elements, :only => [:index, :show] do
         post 'webhook', :on => :collection if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,6 @@ Rails.application.routes.draw do
         end
         resources :collections, :only => [:index, :show]
       end
-      resources :elements, :only => [:index, :show] do
-        post 'webhook', :on => :collection if Rails.env.development?
-      end
-      resources :collections, :only => [:index, :show]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  match '*all' => 'api#options', :via => :options
+
   # ---------------------------------------- API
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :properties, :only => [:show]
+      resources :properties, :only => [:show] do
+        resources :elements, :only => [:index, :show, :create]
+      end
       resources :elements, :only => [:index, :show] do
         post 'webhook', :on => :collection if Rails.env.development?
       end

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::CollectionsController do
 
   before(:each) do
-    @property = property_with_templates
+    @property = property_with_templates_and_collection_types
   end
 
   describe '#index' do
@@ -19,16 +19,35 @@ describe Api::V1::CollectionsController do
       expect { get :index, :property_id => @property.id, :api_key => '123' }
         .to raise_error(ActionController::RoutingError)
     end
-    it 'responds with the collections as json' do
-      c_01 = create(:collection, :with_items, :property => @property)
-      c_02 = create(:collection, :with_items, :property => @property)
-      c_03 = create(:collection, :with_items,
-                    :property => property_with_templates)
-      response = get :index, :property_id => @property.id,
-                     :api_key => @property.api_key, :format => :json
-      expect(response.body).to include(c_01.to_json)
-      expect(response.body).to include(c_02.to_json)
-      expect(response.body).to_not include(c_03.to_json)
+    context 'with collections' do
+      before(:each) do
+        @c_01 = create(:collection, :with_items, :property => @property)
+        @c_02 = create(:collection, :with_items, :with_options,
+                       :property => @property)
+        @c_03 = create(:collection, :with_items, :with_options,
+                       :property => property_with_templates_and_collection_types)
+      end
+      it 'responds with all property collections as json' do
+        response = get :index, :property_id => @property.id,
+                       :api_key => @property.api_key, :format => :json
+        expect(response.body).to include(@c_01.to_json)
+        expect(response.body).to include(@c_02.to_json)
+        expect(response.body).to_not include(@c_03.to_json)
+      end
+      it 'filters collections by type if specified' do
+        response = get :index, :property_id => @property.id,
+                       :api_key => @property.api_key, :format => :json,
+                       :type => 'Default Collection'
+        expect(response.body).to include(@c_01.to_json)
+        expect(response.body).to_not include(@c_02.to_json)
+        expect(response.body).to_not include(@c_03.to_json)
+      end
+      it 'returns no collections if the type does not exist' do
+        response = get :index, :property_id => @property.id,
+                       :api_key => @property.api_key, :format => :json,
+                       :type => 'WRONG! Collection'
+        expect(response.body).to eq('[]')
+      end
     end
   end
 

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -7,12 +7,16 @@ describe Api::V1::CollectionsController do
   end
 
   describe '#index' do
-    it 'raises 403 when no api_key' do
+    it 'raises a URL generation error when no property' do
       expect { get :index }
+        .to raise_error(ActionController::UrlGenerationError)
+    end
+    it 'raises 403 when no api_key' do
+      expect { get :index, :property_id => @property.id }
         .to raise_error(ActionController::RoutingError)
     end
     it 'raises 403 when api_key does not match a property' do
-      expect { get :index, :api_key => '123' }
+      expect { get :index, :property_id => @property.id, :api_key => '123' }
         .to raise_error(ActionController::RoutingError)
     end
     it 'responds with the collections as json' do
@@ -20,8 +24,8 @@ describe Api::V1::CollectionsController do
       c_02 = create(:collection, :with_items, :property => @property)
       c_03 = create(:collection, :with_items,
                     :property => property_with_templates)
-      response = get :index, :api_key => @property.api_key,
-                     :format => :json
+      response = get :index, :property_id => @property.id,
+                     :api_key => @property.api_key, :format => :json
       expect(response.body).to include(c_01.to_json)
       expect(response.body).to include(c_02.to_json)
       expect(response.body).to_not include(c_03.to_json)
@@ -29,20 +33,26 @@ describe Api::V1::CollectionsController do
   end
 
   describe '#show' do
+    before(:each) do
+      @collection = create(:collection, :with_items, :property => @property)
+    end
+    it 'raises a URL generation error when no property' do
+      expect { get :show }
+        .to raise_error(ActionController::UrlGenerationError)
+    end
     it 'raises 403 when no api_key' do
       expect {
-        get :show, :id => @property
+        get :show, :property_id => @property.id, :id => @collection
       }.to raise_error(ActionController::RoutingError)
     end
     it 'raises 403 when api_key does not match a property' do
-      expect {
-        get :show, :id => @property, :api_key => '123'
+      expect { get :show, :property_id => @property.id, :id => @collection,
+                   :api_key => '123'
       }.to raise_error(ActionController::RoutingError)
     end
     it 'responds with the collection as json' do
-      @collection = create(:collection, :with_items, :property => @property)
-      response = get :show, :id => @collection, :api_key => @property.api_key,
-                     :format => :json
+      response = get :show, :property_id => @property.id, :id => @collection,
+                     :api_key => @property.api_key, :format => :json
       expect(response.body).to eq(@collection.to_json)
     end
   end

--- a/spec/controllers/api/v1/elements_controller_spec.rb
+++ b/spec/controllers/api/v1/elements_controller_spec.rb
@@ -8,32 +8,41 @@ describe Api::V1::ElementsController do
 
   describe '#index' do
     before(:each) do
-      @elements = create_list(:element, 5, :with_options, :property => @property)
+      @elements = create_list(:element, 5, :with_options,
+                              :property => @property)
+    end
+    it 'raises a URL generation error when no property' do
+      expect {
+        get :index, :format => :json
+      }.to raise_error(ActionController::UrlGenerationError)
     end
     it 'raises 404 when no api_key' do
       expect {
-        get :index, :format => :json
+        get :index, :property_id => @property.id, :format => :json
       }.to raise_error(ActionController::RoutingError)
     end
     it 'raises 404 when api_key does not match a property' do
-      expect {
-        get :index, :api_key => '123', :format => :json
+      expect { get :index, :property_id => @property.id, :api_key => '123',
+                   :format => :json
       }.to raise_error(ActionController::RoutingError)
     end
     it 'responds with the element as json' do
-      response = get :index, :api_key => @property.api_key, :format => :json
+      response = get :index, :property_id => @property.id,
+                     :api_key => @property.api_key, :format => :json
       expect(response.body).to eq(@property.elements.by_title.to_json)
     end
     context 'when specifying a template' do
       it 'returns an empty array when template does not exist' do
-        response = get :index, :template => 'BLARGH',
-                       :api_key => @property.api_key, :format => :json
+        response = get :index, :property_id => @property.id,
+                       :template => 'BLARGH', :api_key => @property.api_key,
+                       :format => :json
         expect(response.body).to eq('[]')
       end
       it 'returns an empty array when template does not exist' do
         # Create an element without the All Options template
         create(:element, :property => @property)
-        response = get :index, :template => 'All Options',
+        response = get :index, :property_id => @property.id,
+                       :template => 'All Options',
                        :api_key => @property.api_key, :format => :json
         expect(@property.elements.count).to eq(6)
         elements = @property.elements.with_template('All Options').by_title
@@ -43,8 +52,9 @@ describe Api::V1::ElementsController do
     describe 'ordering' do
       it 'orders by attribute when told so' do
         create(:element, :property => @property)
-        response = get :index, :order => 'comments',
-                       :api_key => @property.api_key, :format => :json
+        response = get :index, :property_id => @property.id,
+                       :order => 'comments', :api_key => @property.api_key,
+                       :format => :json
         expect(response.body)
           .to eq(@property.elements.by_field('comments').to_json)
       end
@@ -58,26 +68,30 @@ describe Api::V1::ElementsController do
     before(:each) do
       @element = create(:element, :with_options, :property => @property)
     end
-    it 'raises 404 when no api_key' do
+    it 'raises a URL generation error when no property' do
       expect {
         get :show, :id => @element, :format => :json
+      }.to raise_error(ActionController::UrlGenerationError)
+    end
+    it 'raises 404 when no api_key' do
+      expect { get :show, :property_id => @property.id, :id => @element,
+                   :format => :json
       }.to raise_error(ActionController::RoutingError)
     end
     it 'raises 404 when element does not belong to property' do
       element = create(:element, :with_options)
-      expect {
-        get :show, :id => element, :api_key => @property.api_key,
-            :format => :json
+      expect { get :show, :property_id => @property.id, :id => element,
+                   :api_key => @property.api_key, :format => :json
       }.to raise_error(ActionController::RoutingError)
     end
     it 'raises 404 when api_key does not match property' do
-      expect {
-        get :show, :id => @element, :api_key => '123', :format => :json
+      expect { get :show, :property_id => @property.id, :id => @element,
+                   :api_key => '123', :format => :json
       }.to raise_error(ActionController::RoutingError)
     end
     it 'responds with the element as json' do
-      response = get :show, :id => @element, :api_key => @property.api_key,
-                     :format => :json
+      response = get :show, :property_id => @property.id, :id => @element,
+                     :api_key => @property.api_key, :format => :json
       expect(response.body).to eq(@element.to_json)
     end
   end
@@ -85,6 +99,11 @@ describe Api::V1::ElementsController do
   # ---------------------------------------- Create
 
   describe '#create' do
+    it 'raises a URL generation error when no property' do
+      expect {
+        post :create, :format => :json
+      }.to raise_error(ActionController::UrlGenerationError)
+    end
     it 'raises 404 when no api_key' do
       expect {
         post :create, :property_id => @property.id, :format => :json

--- a/spec/controllers/api/v1/elements_controller_spec.rb
+++ b/spec/controllers/api/v1/elements_controller_spec.rb
@@ -82,4 +82,44 @@ describe Api::V1::ElementsController do
     end
   end
 
+  # ---------------------------------------- Create
+
+  describe '#create' do
+    it 'raises 404 when no api_key' do
+      expect {
+        post :create, :property_id => @property.id, :format => :json
+      }.to raise_error(ActionController::RoutingError)
+    end
+    it 'raises 404 when api_key does not match property' do
+      expect {
+        post :create, :property_id => @property.id, :api_key => '123',
+             :format => :json
+      }.to raise_error(ActionController::RoutingError)
+    end
+    it 'raises 404 when template does not belong to site' do
+      expect {
+        post :create, :property_id => @property.id,
+             :api_key => @property.api_key, :format => :json,
+             :template => 'BAD TEMPLATE'
+      }.to raise_error(ActionController::RoutingError)
+    end
+    it 'will create an element and return the element as json' do
+      expect(@property.elements.count).to eq(0)
+      response = post :create, :property_id => @property.id,
+                      :api_key => @property.api_key, :format => :json,
+                      :name => (name = Faker::Lorem.words(4).join(' ')),
+                      :template => 'Default'
+      expect(response.body).to eq(@property.elements.first.to_json)
+      expect(@property.elements.count).to eq(1)
+      expect(@property.elements.first.title).to eq(name)
+    end
+    it 'returns validation errors if there are any' do
+      response = post :create, :property_id => @property.id,
+                      :api_key => @property.api_key, :format => :json,
+                      :name1 => 'BLAH BLAH', :template => 'Default'
+      expect(response.body)
+        .to eq({"title": ["can't be blank", "can't be blank"]}.to_json)
+    end
+  end
+
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -55,7 +55,7 @@ describe UsersController do
       it 'returns 404 for an admin' do
         @user = create(:admin)
         sign_in @user
-        expect { get :index, :property_id => '123' }
+        expect { get :index, :property_id => '123456' }
           .to raise_error(ActionController::RoutingError)
       end
     end

--- a/spec/features/collections/add_collection_spec.rb
+++ b/spec/features/collections/add_collection_spec.rb
@@ -63,6 +63,7 @@ feature 'Collections', :js => true do
 
     scenario 'it does not allow a fourth level of building' do
       fill_in 'collection[title]', :with => Faker::Lorem.words(4).join(' ')
+      expect(page).to have_css('select.new option', :wait => 5)
       first('select.new').first(:option, @elements[0].title).select_option
       within('article.item.level-1') do
         first('select.new').first(:option, @elements[1].title).select_option
@@ -75,6 +76,7 @@ feature 'Collections', :js => true do
 
     scenario 'it can remove an item at each level' do
       fill_in 'collection[title]', :with => Faker::Lorem.words(4).join(' ')
+      expect(page).to have_css('select.new option', :wait => 5)
       first('select.new').first(:option, @elements[0].title).select_option
       within('article.item.level-1') do
         first('select.new').first(:option, @elements[1].title).select_option
@@ -95,6 +97,7 @@ feature 'Collections', :js => true do
 
     scenario 'removing a parent removes all its children' do
       fill_in 'collection[title]', :with => Faker::Lorem.words(4).join(' ')
+      expect(page).to have_css('select.new option', :wait => 5)
       first('select.new').first(:option, @elements[0].title).select_option
       within('article.item.level-1') do
         first('select.new').first(:option, @elements[1].title).select_option
@@ -111,6 +114,7 @@ feature 'Collections', :js => true do
     scenario 'it will save the collection after removing an item' do
       title = Faker::Lorem.words(4).join(' ')
       fill_in 'collection[title]', :with => title
+      expect(page).to have_css('select.new option', :wait => 5)
       first('select.new').first(:option, @elements[0].title).select_option
       within('article.item.level-1') do
         first('select.new').first(:option, @elements[1].title).select_option

--- a/spec/features/elements/add_element_spec.rb
+++ b/spec/features/elements/add_element_spec.rb
@@ -47,9 +47,15 @@ feature 'Elements', :js => true do
       document = create(:document, :property => @property)
       click_link 'Choose Existing File'
       wait_for_ajax
-      click_link document.title
       sleep 0.35
-      within('form') { expect(page).to have_content(document.title) }
+      within('#modal') do
+        expect(page).to have_content(document.title, :wait => 5)
+        click_link document.title
+      end
+      sleep 0.35
+      within('form') do
+        expect(page).to have_content(document.title, :wait => 5)
+      end
       fill_in 'element[template_data][name]', :with => @title
       click_button 'Save All Options'
       # Let's see if it persisted.

--- a/spec/features/elements/edit_element_spec.rb
+++ b/spec/features/elements/edit_element_spec.rb
@@ -42,9 +42,15 @@ feature 'Elements', :js => true do
       document = create(:document, :property => @property)
       click_link 'Choose Existing File'
       wait_for_ajax
-      click_link document.title
       sleep 0.35
-      within('form') { expect(page).to have_content(document.title) }
+      within('#modal') do
+        expect(page).to have_content(document.title, :wait => 5)
+        click_link document.title
+      end
+      sleep 0.35
+      within('form') do
+        expect(page).to have_content(document.title, :wait => 5)
+      end
       # Let's see if it persisted.
       click_button 'Save All Options'
       click_link @element.title


### PR DESCRIPTION
- Create elements via the API
- Add a `text` field for elements for a plain text field
- Ignore collection's elements that don't exist
- Force API calls to be nested under a property
- Optionally filter collections API calls by type