### PR TITLE
v2.0.0-beta.02 [API Caching]

### DIFF
--- a/app/controllers/api/v1/elements_controller.rb
+++ b/app/controllers/api/v1/elements_controller.rb
@@ -6,13 +6,13 @@ class Api::V1::ElementsController < ApiController
         options = {}
         @elements = if params[:template]
           options = { :includes => params[:includes] } if params[:includes]
-          current_property.elements.with_template(params[:template]).with_associations
+          current_property.elements.with_template(params[:template])
         else
-          current_property.elements.with_associations
+          current_property.elements
         end
         @elements = if params[:sort_by] || params[:order]
           @elements.by_field(params[:sort_by] || params[:order],
-                             params[:sort_in])
+                             params[:sort_in]).with_associations
         else
           @elements.by_title.with_associations
         end

--- a/app/controllers/api/v1/elements_controller.rb
+++ b/app/controllers/api/v1/elements_controller.rb
@@ -6,15 +6,15 @@ class Api::V1::ElementsController < ApiController
         options = {}
         @elements = if params[:template]
           options = { :includes => params[:includes] } if params[:includes]
-          current_property.elements.with_template(params[:template])
+          current_property.elements.with_template(params[:template]).with_associations
         else
-          current_property.elements
+          current_property.elements.with_associations
         end
         @elements = if params[:sort_by] || params[:order]
           @elements.by_field(params[:sort_by] || params[:order],
                              params[:sort_in])
         else
-          @elements.by_title
+          @elements.by_title.with_associations
         end
         render(:json => @elements.to_json(options))
       end
@@ -24,9 +24,10 @@ class Api::V1::ElementsController < ApiController
   def show
     respond_to do |f|
       f.json do
-        @element = current_property.elements.find_by_id(params[:id])
+        @element = current_property.elements.where(:id => params[:id])
+                                   .with_associations[0]
         not_found if @element.nil?
-        render(:json => @element.to_json(:includes => params[:includes]))
+        render(:json => @element.to_json)
       end
     end
   end
@@ -42,7 +43,7 @@ class Api::V1::ElementsController < ApiController
     @element.template_name = @template.name
     if @element.save
       @element.send_notifications!(action_name)
-      render :json => @element
+      render :json => @element.to_json
     else
       render :json => @element.errors.messages
     end

--- a/app/controllers/api/v1/elements_controller.rb
+++ b/app/controllers/api/v1/elements_controller.rb
@@ -27,7 +27,8 @@ class Api::V1::ElementsController < ApiController
         @element = current_property.elements.where(:id => params[:id])
                                    .with_associations[0]
         not_found if @element.nil?
-        render(:json => @element.to_json)
+        options = params[:includes] ? { :includes => params[:includes] } : {}
+        render(:json => @element.to_json(options))
       end
     end
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -16,11 +16,11 @@ class ApiController < ActionController::Base
   protected
 
     def index_cache_path
-      "_p#{current_property.id}_#{controller_name}#{q_to_s}"
+      "_p#{current_property.id}_#{controller_name}\#index#{q_to_s}"
     end
 
     def show_cache_path
-      "_p#{current_property.id}_#{controller_name}_#{params[:id]}#{q_to_s}"
+      "_p#{current_property.id}_#{controller_name}\#show_#{params[:id]}#{q_to_s}"
     end
 
     def q_to_s

--- a/app/models/element.rb
+++ b/app/models/element.rb
@@ -112,7 +112,7 @@ class Element < ActiveRecord::Base
     ProcessImages.delay.call(:document => self) if image? && !processed?
   end
 
-  after_commit :update_associations
+  after_save :update_associations
 
   def update_associations
     return if template.blank?
@@ -121,7 +121,7 @@ class Element < ActiveRecord::Base
     element_fields.collect(&:name).each do |f|
       ids += (template_data[f] || '').split(',').map(&:to_i)
     end
-    self.associated_elements = Element.where(:id => ids)
+    self.associated_elements = property.elements.where(:id => ids)
     SapwoodCache.rebuild_element(self)
   end
 

--- a/app/models/element_association.rb
+++ b/app/models/element_association.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: element_associations
+#
+#  id         :integer          not null, primary key
+#  source_id  :integer
+#  target_id  :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class ElementAssociation < ActiveRecord::Base
+
+  # ---------------------------------------- Associations
+
+  belongs_to :source, :class_name => 'Element'
+  belongs_to :target, :class_name => 'Element'
+
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -44,11 +44,11 @@ class Property < ActiveRecord::Base
     update_columns(:api_key => SecureRandom.hex(25))
   end
 
-  after_touch :expire_caches
   after_save :expire_caches
 
-  def expire_caches
-    Rails.cache.delete_matched(/\_p#{id}\_(.*)/) if Rails.env.production?
+  def expire_caches(force = false)
+    return true unless force || (SapwoodCache.enabled? && templates_raw_changed?)
+    SapwoodCache.rebuild_property(self)
   end
 
   # ---------------------------------------- Instance Methods

--- a/app/services/sapwood_cache.rb
+++ b/app/services/sapwood_cache.rb
@@ -1,0 +1,55 @@
+class SapwoodCache
+
+  def self.enabled?
+    Rails.application.config.action_controller.perform_caching
+  end
+
+  def self.rebuild_property(property)
+    new.rebuild_property(property)
+  end
+
+  def self.rebuild_element(element)
+    new.rebuild_element(element)
+  end
+
+  def self.delete_property(property)
+    Rails.cache.delete_matched(/\_p#{property.id}\_(.*)/)
+    Rails.logger.info "DELETE CACHE: [/\_p#{property.id}\_(.*)/]"
+  end
+
+  def self.delete_element(el)
+    p_id = el.property.id
+    # Caches on the ActiveRecord object (Element).
+    Rails.cache.delete_matched(/\_p#{p_id}\_e#{el.id}\_(.*)/)
+    Rails.logger.info "DELETE CACHE: /\_p#{p_id}\_e#{el.id}\_(.*)/"
+    # api/elements#show
+    Rails.cache.delete_matched(/\_p#{p_id}\_elements\#show\_#{el.id}\_(.*)/)
+    Rails.logger.info "DELETE CACHE: /\_p#{p_id}\_elements\#show\_#{el.id}\_(.*)/"
+    # api/elements#index
+    Rails.cache.delete_matched(/\_p#{p_id}\_elements\#index(.*)/)
+    Rails.logger.info "DELETE CACHE: /\_p#{p_id}\_elements\#index(.*)/"
+  end
+
+  def rebuild_property(property)
+    return unless SapwoodCache.enabled?
+    SapwoodCache.delete_property(property)
+    property.elements.each { |el| el.reload.as_json }
+  end
+
+  def rebuild_element(element)
+    return unless SapwoodCache.enabled?
+    elements = element.associated_to_as_target
+    # Bust the element's cache.
+    SapwoodCache.delete_element(element)
+    # Bust cache of element's that have this one in their associations.
+    elements.each { |el| SapwoodCache.delete_element(el) }
+    # Rebuild this element's as_json (without includes) cache.
+    element.reload.as_json
+    # Rebuild associated elements' as_json (without includes) cache.
+    elements.each { |el| el.reload.as_json }
+  end
+
+  handle_asynchronously :rebuild_property
+  handle_asynchronously :rebuild_element
+
+end

--- a/app/services/sapwood_cache.rb
+++ b/app/services/sapwood_cache.rb
@@ -28,6 +28,12 @@ class SapwoodCache
     # api/elements#index
     Rails.cache.delete_matched(/\_p#{p_id}\_elements\#index(.*)/)
     Rails.logger.info "DELETE CACHE: /\_p#{p_id}\_elements\#index(.*)/"
+    # api/collections#show
+    Rails.cache.delete_matched(/\_p#{p_id}\_collections\#show\_#{el.id}\_(.*)/)
+    Rails.logger.info "DELETE CACHE: /\_p#{p_id}\_collections\#show\_#{el.id}\_(.*)/"
+    # api/collections#index
+    Rails.cache.delete_matched(/\_p#{p_id}\_collections\#index(.*)/)
+    Rails.logger.info "DELETE CACHE: /\_p#{p_id}\_collections\#index(.*)/"
   end
 
   def rebuild_property(property)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -48,6 +48,7 @@ Rails.application.configure do
 
   config.after_initialize do
     Bullet.enable = true
+    # Bullet.rails_logger = true
     Bullet.add_footer = true
   end
 end

--- a/db/migrate/20161122203838_create_element_associations.rb
+++ b/db/migrate/20161122203838_create_element_associations.rb
@@ -1,0 +1,12 @@
+class CreateElementAssociations < ActiveRecord::Migration
+  def change
+    create_table :element_associations do |t|
+      t.integer :source_id
+      t.integer :target_id
+
+      t.timestamps null: false
+    end
+
+    Element.all.each { |e| e.update!(:skip_geocode => true) }
+  end
+end

--- a/db/migrate/20161123125018_build_element_caches.rb
+++ b/db/migrate/20161123125018_build_element_caches.rb
@@ -1,0 +1,5 @@
+class BuildElementCaches < ActiveRecord::Migration
+  def up
+    Element.all.each { |el| el.delay.as_json }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161106215420) do
+ActiveRecord::Schema.define(version: 20161123125018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,13 @@ ActiveRecord::Schema.define(version: 20161106215420) do
     t.datetime "updated_at",                  null: false
     t.boolean  "archived",    default: false
     t.boolean  "processed",   default: false
+  end
+
+  create_table "element_associations", force: :cascade do |t|
+    t.integer  "source_id"
+    t.integer  "target_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "elements", force: :cascade do |t|

--- a/spec/features/elements/element_geocoder_spec.rb
+++ b/spec/features/elements/element_geocoder_spec.rb
@@ -61,7 +61,7 @@ feature 'Geocoder', :js => true do
     end
     scenario 'provides geocode feedback for a valid address' do
       fill_in 'element[template_data][address]', :with => 'lytle place, 45202'
-      expect(page).to have_content('Lytle Pl, Cincinnati, OH 45202, USA')
+      expect(page).to have_content('Lytle St, Cincinnati, OH 45202, USA')
     end
     scenario 'provides feedback if it can not locate an address' do
       fill_in 'element[template_data][address]', :with => 'jkhjklhjkljkhlkjlh'
@@ -79,7 +79,7 @@ feature 'Geocoder', :js => true do
       click_link @element.title
       value = find_field('element[template_data][address]').value
       expect(value).to eq('lytle place, 45202')
-      expect(page).to have_content('Lytle Pl, Cincinnati, OH 45202, USA')
+      expect(page).to have_content('Lytle St, Cincinnati, OH 45202, USA')
     end
   end
 


### PR DESCRIPTION
Focus here is all about #176 and being smarter about how we cache and how we target busting caches. By offloading a lot of this logic into the background we can keep page load times down through the UI and the API.

This exposes the app to serving stale data if DelayedJob is not running. I've not seen a problem with that in a long time, but it's something to be aware of.