### PR TITLE
[#241] Remove Geocoding

### DIFF
--- a/db/migrate/20180611110526_convert_geocode_fields_to_text.rb
+++ b/db/migrate/20180611110526_convert_geocode_fields_to_text.rb
@@ -1,0 +1,20 @@
+class ConvertGeocodeFieldsToText < ActiveRecord::Migration[5.2]
+
+  def up
+    Property.all.each do |property|
+      config = JSON.parse(property.templates_raw)
+      update = false
+      config.each_with_index do |data, idx|
+        data.deep_stringify_keys!
+        data['fields'].each do |name, fdata|
+          if fdata['type'] == 'geocode'
+            config[idx]['fields'][name]['type'] = 'text'
+            update = true
+          end
+        end
+      end
+      property.update_columns(templates_raw: config.to_json) if update
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_09_133718) do
+ActiveRecord::Schema.define(version: 2018_06_11_110526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Builds upon the original work for removing geocoding by adding a migration that converts all existing geocode fields to text fields.

This approach has two drawbacks:

1. It removes indentation and extra whitespaces in data configs. I'm not worried about this because this config text is going away as we transition templates and fields into the database.

2. The value of the fields that were geocode fields are now plain-text representations of the geocode object (hash). I also think this is okay because it provides developers the opportunity to transition this data as needed for their individual properties.